### PR TITLE
feat: Implement Works page with ContentCollection

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,17 @@
+import { defineCollection, z } from 'astro:content';
+
+const worksCollection = defineCollection({
+  type: 'content', // 'content' for Markdown/MDX files, 'data' for JSON/YAML
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    image: z.string(), // For the thumbnail
+    date: z.date(),
+    tags: z.array(z.string()), // For genre
+    // 'body' is not part of the schema, as it refers to the main content of the entry
+  }),
+});
+
+export const collections = {
+  'works': worksCollection,
+};

--- a/src/content/works/work1.md
+++ b/src/content/works/work1.md
@@ -1,0 +1,18 @@
+---
+title: "First Project"
+description: "This is a description of the first amazing project."
+image: "/images/placeholder-work1.jpg"
+date: 2023-10-26
+tags: ["Web Development", "Astro"]
+---
+
+# My First Project
+
+This is the main content of my first project. It's still a work in progress, but I'm excited to share it.
+
+Here are some features:
+- Feature A
+- Feature B
+- Feature C
+
+More details to come!

--- a/src/content/works/work2.md
+++ b/src/content/works/work2.md
@@ -1,0 +1,18 @@
+---
+title: "Second Endeavor"
+description: "A detailed account of the second innovative endeavor."
+image: "/images/placeholder-work2.jpg"
+date: 2024-01-15
+tags: ["Graphic Design", "Portfolio"]
+---
+
+# The Second Endeavor
+
+Welcome to the documentation of my second major endeavor. This project focuses on innovative graphic design.
+
+Key aspects:
+- Aspect X
+- Aspect Y
+- Aspect Z
+
+Stay tuned for updates.

--- a/src/pages/works.astro
+++ b/src/pages/works.astro
@@ -1,52 +1,154 @@
 ---
-import Layout from "src/layouts/Layout.astro";
-import { css } from "styled-system/css";
+import Layout from "src/layouts/Layout.astro"; // Standard layout component
+import { getCollection } from 'astro:content'; // For fetching content collections
+import { css } from "styled-system/css"; // For PandaCSS styling
 
-const tableContainer = css({
-  display: "grid",
-  gridTemplateColumns: "repeat(3, 1fr)",
-  gridTemplateRows: "repeat(3, 300px)",
-  gap: "1px",
-  background: "border",
-  w: "full",
-  h: "full",
-  border: "1px solid",
-  borderColor: "border",
+// Fetch all entries from the 'works' collection
+const allWorks = await getCollection('works');
+
+// Styles for the page layout and work items
+// These are basic styles and can be refined later.
+
+const mainPageStyles = css({
+  width: "full",
+  maxWidth: "1200px", // Limit max width for better readability on large screens
+  margin: "0 auto", // Center the content
+  padding: { base: "4", md: "6" }, // Responsive padding (e.g., p_4, md:p_6)
+  display: 'flex',
+  flexDirection: 'column',
+  gap: { base: "6", md: "8" }, // Responsive gap (e.g., gap_6, md:gap_8)
 });
 
-const cell = css({
-  w: "full",
-  h: "full",
-  background: "background",
+const pageTitleStyles = css({
+  fontSize: { base: "2xl", md: "3xl" }, // Responsive font size (e.g., text_2xl, md:text_3xl)
+  fontWeight: "bold",
+  textAlign: "center",
+  color: "token(colors.gray.800)", // Example: Use a token for color
+  marginBottom: { base: "4", md: "6" }, // Responsive margin (e.g., mb_4, md:mb_6)
+  letterSpacing: "tight", // Added for tighter letter spacing
+});
+
+const worksGridStyles = css({
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fill, minmax(min(100%, 300px), 1fr))", // Responsive grid columns
+  gap: { base: "4", md: "6" }, // Responsive gap
+  listStyle: "none", // Remove default list styling
+  padding: "0", // Remove default padding
+});
+
+const workCardStyles = css({
+  display: "flex", // Use flex for internal layout of card
+  flexDirection: "column",
+  border: "1px solid token(colors.gray.200)", // Example border color
+  borderRadius: "lg", // e.g., br_lg
+  overflow: "hidden", // Ensure content respects border radius
+  textDecoration: "none",
+  color: "inherit",
+  backgroundColor: "token(colors.white)", // Card background
+  boxShadow: "md", // Added default medium shadow
+  transition: "box-shadow 0.3s ease, transform 0.2s ease, border-color 0.2s ease", // Added border-color to transition
+  _hover: {
+    boxShadow: "xl", // e.g., shadow_xl
+    transform: "translateY(-4px)",
+    borderColor: "token(colors.blue.400)",
+  },
+});
+
+const workImageContainerStyles = css({
+  width: "100%",
+  height: "200px", // Fixed height for the image area
+  overflow: "hidden", // Clip image if it's too large
+});
+
+const workImageStyles = css({
+  width: "100%",
+  height: "100%",
+  objectFit: "cover", // Cover the container, cropping if necessary
+  transition: "transform 0.3s ease-out",
+  _hover: { // Slight zoom effect on image hover (within card)
+    transform: "scale(1.05)",
+  }
+});
+
+const workContentStyles = css({
+  padding: "1rem", // p_4
+  display: "flex",
+  flexDirection: "column",
+  flexGrow: "1", // Allows content to fill space, useful for tags at bottom
+});
+
+const workTitleStyles = css({
+  fontSize: "lg", // e.g., text_lg
+  fontWeight: "semibold",
+  color: "token(colors.gray.700)",
+  marginBottom: "0.5rem", // mb_2
+  transition: "color 0.2s ease-in-out", // Added transition for potential color changes
+  _hover: {
+    // Example: color: "token(colors.blue.600)" // If the title itself was a link or had interaction
+  }
+});
+
+const workDescriptionStyles = css({
+  fontSize: "sm", // e.g., text_sm
+  color: "token(colors.gray.600)",
+  marginBottom: "0.75rem", // mb_3
+  flexGrow: "1", // Pushes tags to the bottom
+});
+
+const workTagsContainerStyles = css({
+  marginTop: "auto", // Pushes tags to the bottom of the card content area
+  paddingTop: "0.5rem", // pt_2, space above tags
+});
+
+const workTagStyles = css({
+  display: "inline-block",
+  backgroundColor: "token(colors.blue.100)",
+  color: "token(colors.blue.800)",
+  padding: "0.25rem 0.75rem", // py_1, px_3
+  borderRadius: "full", // br_full for pill shape
+  fontSize: "xs", // text_xs
+  fontWeight: "medium",
+  marginRight: "0.5rem", // mr_2
+  marginBottom: "0.5rem", // mb_2
+});
+
+const noWorksMessageStyles = css({
+  textAlign: "center",
+  color: "token(colors.gray.500)",
+  padding: "2rem", // p_8
+  fontSize: "lg", // text_lg
 });
 ---
 
-<Layout>
-  <main
-    class={css({
-      w: "full",
-      h: "full",
-      padding: "4",
-      display: "grid",
-      gridTemplateColumns: "1fr",
-      border: "1px solid",
-      borderColor: "border",
-      gap: "12",
-      md: {
-        gap: "4",
-      },
-    })}
-  >
-    <div class={tableContainer}>
-      <div class={cell}>a</div>
-      <div class={cell}>b</div>
-      <div class={cell}>c</div>
-      <div class={cell}>d</div>
-      <div class={cell}>e</div>
-      <div class={cell}>e</div>
-      <div class={cell}>e</div>
-      <div class={cell}>e</div>
-      <div class={cell}>e</div>
-    </div>
+<Layout title="My Works - Portfolio">
+  <main class={mainPageStyles}>
+    <h1 class={pageTitleStyles}>
+      Explore My Portfolio
+    </h1>
+
+    {allWorks.length === 0 ? (
+      <p class={noWorksMessageStyles}>
+        It looks like there are no works to display at the moment. Please check back soon!
+      </p>
+    ) : (
+      <div class={worksGridStyles}>
+        {allWorks.map(work => (
+          <a href={`/works/${work.slug}`} class={workCardStyles} aria-label={`View details for ${work.data.title}`}>
+            <div class={workImageContainerStyles}>
+              <img src={work.data.image} alt={`Thumbnail for ${work.data.title}`} class={workImageStyles} />
+            </div>
+            <div class={workContentStyles}>
+              <h2 class={workTitleStyles}>{work.data.title}</h2>
+              <p class={workDescriptionStyles}>{work.data.description.length > 100 ? work.data.description.slice(0, 97) + "..." : work.data.description}</p>
+              <div class={workTagsContainerStyles}>
+                {work.data.tags.map(tag => (
+                  <span class={workTagStyles}>{tag}</span>
+                ))}
+              </div>
+            </div>
+          </a>
+        ))}
+      </div>
+    )}
   </main>
 </Layout>

--- a/src/pages/works/[slug].astro
+++ b/src/pages/works/[slug].astro
@@ -1,0 +1,169 @@
+---
+import { getCollection } from 'astro:content';
+import Layout from 'src/layouts/Layout.astro';
+import { css } from 'styled-system/css'; // For PandaCSS
+
+export async function getStaticPaths() {
+  const worksEntries = await getCollection('works');
+  return worksEntries.map(work => ({
+    params: { slug: work.slug },
+    props: { work },
+  }));
+}
+
+const { work } = Astro.props;
+const { Content } = await work.render();
+
+// Basic styles
+const pageStyles = css({
+  maxWidth: '800px',
+  margin: '0 auto',
+  padding: { base: '1rem', md: '2rem' },
+  fontFamily: 'sans-serif', // Assuming a base font is set globally in PandaCSS config
+  // backgroundColor: 'token(colors.white)', // Optional: if page bg needs to differ from layout
+  // boxShadow: 'sm', // Optional: if page needs a slight lift
+});
+
+const titleStyles = css({
+  fontSize: { base: '2xl', md: '3xl' },
+  fontWeight: 'bold',
+  marginBottom: '0.75rem',
+  color: 'token(colors.gray.800)',
+  letterSpacing: 'tight', // Added for consistency
+  lineHeight: 'shorter', // Added for better heading appearance
+});
+
+const dateStyles = css({
+  fontSize: 'sm',
+  color: 'token(colors.gray.600)',
+  marginBottom: '0.5rem',
+});
+
+const tagsContainerStyles = css({
+  marginBottom: '1rem',
+});
+
+const tagStyles = css({
+  display: 'inline-block',
+  backgroundColor: 'token(colors.blue.100)',
+  color: 'token(colors.blue.800)',
+  padding: '0.25rem 0.75rem',
+  borderRadius: 'full',
+  fontSize: 'xs',
+  fontWeight: 'medium',
+  marginRight: '0.5rem',
+  marginBottom: '0.5rem',
+});
+
+const imageStyles = css({
+  width: '100%',
+  maxHeight: '400px',
+  objectFit: 'cover',
+  borderRadius: 'lg', // Slightly larger radius
+  marginBottom: '1.5rem',
+  border: '1px solid token(colors.gray.200)',
+  boxShadow: 'md', // Added subtle shadow for depth
+});
+
+const contentStyles = css({
+  lineHeight: '1.75', // Increased line height for readability
+  color: 'token(colors.gray.800)', // Darker text for better contrast
+  wordBreak: 'break-word',
+  '& > :first-child': { marginTop: '0 !important' }, // Ensure no margin on first element
+  '& h1': { fontSize: '2xl', fontWeight: 'bold', mt: '10', mb: '5', color: 'token(colors.gray.900)', lineHeight: 'tight' }, // For h1 within markdown
+  '& h2': { fontSize: 'xl', fontWeight: 'semibold', mt: '8', mb: '4', color: 'token(colors.gray.900)', lineHeight: 'tight' },
+  '& h3': { fontSize: 'lg', fontWeight: 'semibold', mt: '6', mb: '3', color: 'token(colors.gray.900)', lineHeight: 'tight' },
+  '& h4': { fontSize: 'md', fontWeight: 'semibold', mt: '5', mb: '2', color: 'token(colors.gray.900)', lineHeight: 'tight' },
+  '& p': { marginBottom: '1.25rem' }, // Slightly more space between paragraphs
+  '& a': { color: 'token(colors.blue.600)', textDecoration: 'underline', _hover: { color: 'token(colors.blue.800)', textDecorationThickness: '2px' } },
+  '& ul, & ol': { paddingLeft: '1.5rem', marginBottom: '1.25rem', listStylePosition: 'outside' },
+  '& li': { marginBottom: '0.5rem' }, // More space between list items
+  '& li::marker': { color: 'token(colors.gray.500)' },
+  '& blockquote': {
+    borderLeft: '4px solid token(colors.blue.300)',
+    padding: '0.75rem 1rem',
+    margin: '1.5rem 0',
+    fontStyle: 'italic',
+    color: 'token(colors.gray.700)',
+    backgroundColor: 'token(colors.blue.50)',
+    borderRadius: 'sm',
+  },
+  '& pre': {
+    backgroundColor: 'token(colors.gray.800)', // Darker background for code blocks
+    color: 'token(colors.gray.100)', // Light text for contrast
+    padding: '1rem',
+    borderRadius: 'md',
+    overflowX: 'auto',
+    fontSize: 'sm',
+    lineHeight: '1.5', // Code-specific line height
+  },
+  '& code': { // Inline code
+    fontFamily: 'monospace',
+    backgroundColor: 'token(colors.gray.100)',
+    color: 'token(colors.purple.700)', // A distinct color for inline code
+    padding: '0.15rem 0.3rem',
+    borderRadius: 'sm',
+    fontSize: '0.875em', // Slightly smaller than surrounding text
+    wordBreak: 'break-all',
+  },
+  '& pre code': { // Reset for code within pre blocks
+    backgroundColor: 'transparent',
+    color: 'inherit',
+    padding: '0',
+    fontSize: 'inherit',
+    fontFamily: 'inherit', // Inherit monospace from pre
+  },
+  '& hr': {
+    margin: '2rem 0',
+    borderColor: 'token(colors.gray.300)',
+    borderTopWidth: '1px',
+  },
+  '& table': {
+    width: '100%',
+    borderCollapse: 'collapse',
+    margin: '1.5rem 0',
+    fontSize: 'sm',
+    textAlign: 'left',
+  },
+  '& th, & td': {
+    border: '1px solid token(colors.gray.300)',
+    padding: '0.5rem 0.75rem', // p_2 p_3
+  },
+  '& th': {
+    backgroundColor: 'token(colors.gray.100)',
+    fontWeight: 'semibold',
+    color: 'token(colors.gray.700)',
+  },
+  '& img': { // Images within markdown content
+    maxWidth: '100%',
+    height: 'auto',
+    borderRadius: 'md',
+    margin: '1rem 0',
+    boxShadow: 'sm',
+  }
+});
+---
+
+<Layout title={work.data.title + " - My Works"}>
+  <article class={pageStyles}>
+    <header>
+      <h1 class={titleStyles}>{work.data.title}</h1>
+      <p class={dateStyles}>
+        Published on: {new Date(work.data.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+      </p>
+      {work.data.tags && work.data.tags.length > 0 && (
+        <div class={tagsContainerStyles}>
+          {work.data.tags.map(tag => (
+            <span class={tagStyles}>{tag}</span>
+          ))}
+        </div>
+      )}
+    </header>
+
+    <img src={work.data.image} alt={`Cover image for ${work.data.title}`} class={imageStyles} />
+
+    <div class={contentStyles}>
+      <Content />
+    </div>
+  </article>
+</Layout>


### PR DESCRIPTION
This commit introduces a new "Works" section to showcase projects.

Key changes:
- Defined a content schema for works in `src/content/config.ts`, including fields for title, description, image, date, and tags.
- Added sample Markdown content files for individual works in `src/content/works/`.
- Updated `src/pages/works.astro` to display a list of works, fetching data from the content collection. Each item links to a dedicated page.
- Created a dynamic route `src/pages/works/[slug].astro` to display detailed information for each work, including its full Markdown body.
- Applied consistent styling using PandaCSS (`styled-system/css`) to both the list and detail pages, ensuring a polished look and feel that aligns with the existing website design.